### PR TITLE
Bump NuGet dependencies (Polyfill 10.0.0, Spectre.Console 0.55.0, TUnit 1.28.7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
         patterns:
           - "*"
         update-types:
+          - major
           - minor
           - patch
   - package-ecosystem: dotnet-sdk

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   fix-lock-files:
     name: Fix Lock Files
-    if: github.actor == 'dependabot[bot]' || startsWith(github.head_ref, 'deps/')
+    if: github.actor == 'dependabot[bot]' || (startsWith(github.head_ref, 'deps/') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   fix-lock-files:
     name: Fix Lock Files
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || startsWith(github.head_ref, 'deps/')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="Pastel" Version="7.0.1" />
     <PackageVersion Include="Polly.Core" Version="8.6.6" />
-    <PackageVersion Include="Polyfill" Version="9.24.0">
+    <PackageVersion Include="Polyfill" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
@@ -31,11 +31,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
-    <PackageVersion Include="Spectre.Console.ImageSharp" Version="0.54.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.55.0" />
+    <PackageVersion Include="Spectre.Console.ImageSharp" Version="0.55.0" />
     <PackageVersion Include="System.Interactive" Version="7.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="TUnit" Version="1.24.18" />
+    <PackageVersion Include="TUnit" Version="1.28.7" />
   </ItemGroup>
 </Project>

--- a/samples/ApiVersionInfo/packages.lock.json
+++ b/samples/ApiVersionInfo/packages.lock.json
@@ -10,9 +10,17 @@
       },
       "Spectre.Console": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA=="
+        "requested": "[0.55.0, )",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
       },
       "GW2SDK": {
         "type": "Project"

--- a/samples/MostVersatileMaterials/packages.lock.json
+++ b/samples/MostVersatileMaterials/packages.lock.json
@@ -71,18 +71,21 @@
       },
       "Spectre.Console": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA=="
+        "requested": "[0.55.0, )",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
       },
       "Spectre.Console.ImageSharp": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "GiYKGrcxjMyZE0E/Vn/sI799sTDBpsZecsBwu8TccymLxuZHsVPpVwjRGddOUPK2WWONB/aJWdevTRtfNy4a5g==",
+        "requested": "[0.55.0, )",
+        "resolved": "0.55.0",
+        "contentHash": "nXkEQ0FmIRe7U7QxTCCFlXzOKWEHTuNLD8uRf9VjmGXFxfmCEaTUYrXggMxCyEkOVJJHQSsxNZXKd8rSAsZlng==",
         "dependencies": {
           "SixLabors.ImageSharp": "3.1.12",
-          "Spectre.Console": "0.54.0"
+          "Spectre.Console": "0.55.0"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
@@ -407,6 +410,11 @@
           "Polly.Core": "8.4.2",
           "System.Threading.RateLimiting": "8.0.0"
         }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/samples/SpectreMarkup/packages.lock.json
+++ b/samples/SpectreMarkup/packages.lock.json
@@ -10,9 +10,17 @@
       },
       "Spectre.Console": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA=="
+        "requested": "[0.55.0, )",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
       },
       "GW2SDK": {
         "type": "Project"

--- a/src/GuildWars2.TestDataHelper/packages.lock.json
+++ b/src/GuildWars2.TestDataHelper/packages.lock.json
@@ -57,9 +57,12 @@
       },
       "Spectre.Console": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA=="
+        "requested": "[0.55.0, )",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -383,6 +386,11 @@
           "Polly.Core": "8.4.2",
           "System.Threading.RateLimiting": "8.0.0"
         }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/src/GuildWars2/packages.lock.json
+++ b/src/GuildWars2/packages.lock.json
@@ -37,9 +37,9 @@
       },
       "Polyfill": {
         "type": "Direct",
-        "requested": "[9.24.0, )",
-        "resolved": "9.24.0",
-        "contentHash": "fuc6Od4lAp7VbtQG9lWuJFgw+tpdj5uQWUgarYRkzdm/Jbq/YTqPSrX3mrvE8aM25u/j5IX+wFBxxhg/Rvmkkw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "HX4+jlB3OTAn+CiNLzuen/I7jgYLfNxDTsX3A7Ij285WYEbNwXPh1haHgeDinDum+m/pviBb8idK4JNUz1qS0Q=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
@@ -178,9 +178,9 @@
       },
       "Polyfill": {
         "type": "Direct",
-        "requested": "[9.24.0, )",
-        "resolved": "9.24.0",
-        "contentHash": "fuc6Od4lAp7VbtQG9lWuJFgw+tpdj5uQWUgarYRkzdm/Jbq/YTqPSrX3mrvE8aM25u/j5IX+wFBxxhg/Rvmkkw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "HX4+jlB3OTAn+CiNLzuen/I7jgYLfNxDTsX3A7Ij285WYEbNwXPh1haHgeDinDum+m/pviBb8idK4JNUz1qS0Q=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
@@ -298,9 +298,9 @@
       },
       "Polyfill": {
         "type": "Direct",
-        "requested": "[9.24.0, )",
-        "resolved": "9.24.0",
-        "contentHash": "fuc6Od4lAp7VbtQG9lWuJFgw+tpdj5uQWUgarYRkzdm/Jbq/YTqPSrX3mrvE8aM25u/j5IX+wFBxxhg/Rvmkkw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "HX4+jlB3OTAn+CiNLzuen/I7jgYLfNxDTsX3A7Ij285WYEbNwXPh1haHgeDinDum+m/pviBb8idK4JNUz1qS0Q=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
@@ -336,9 +336,9 @@
       },
       "Polyfill": {
         "type": "Direct",
-        "requested": "[9.24.0, )",
-        "resolved": "9.24.0",
-        "contentHash": "fuc6Od4lAp7VbtQG9lWuJFgw+tpdj5uQWUgarYRkzdm/Jbq/YTqPSrX3mrvE8aM25u/j5IX+wFBxxhg/Rvmkkw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "HX4+jlB3OTAn+CiNLzuen/I7jgYLfNxDTsX3A7Ij285WYEbNwXPh1haHgeDinDum+m/pviBb8idK4JNUz1qS0Q=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
@@ -374,9 +374,9 @@
       },
       "Polyfill": {
         "type": "Direct",
-        "requested": "[9.24.0, )",
-        "resolved": "9.24.0",
-        "contentHash": "fuc6Od4lAp7VbtQG9lWuJFgw+tpdj5uQWUgarYRkzdm/Jbq/YTqPSrX3mrvE8aM25u/j5IX+wFBxxhg/Rvmkkw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "HX4+jlB3OTAn+CiNLzuen/I7jgYLfNxDTsX3A7Ij285WYEbNwXPh1haHgeDinDum+m/pviBb8idK4JNUz1qS0Q=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",

--- a/tests/GuildWars2.ArchitectureTests/packages.lock.json
+++ b/tests/GuildWars2.ArchitectureTests/packages.lock.json
@@ -21,21 +21,21 @@
       },
       "Polyfill": {
         "type": "Direct",
-        "requested": "[9.24.0, )",
-        "resolved": "9.24.0",
-        "contentHash": "fuc6Od4lAp7VbtQG9lWuJFgw+tpdj5uQWUgarYRkzdm/Jbq/YTqPSrX3mrvE8aM25u/j5IX+wFBxxhg/Rvmkkw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "HX4+jlB3OTAn+CiNLzuen/I7jgYLfNxDTsX3A7Ij285WYEbNwXPh1haHgeDinDum+m/pviBb8idK4JNUz1qS0Q=="
       },
       "TUnit": {
         "type": "Direct",
-        "requested": "[1.24.18, )",
-        "resolved": "1.24.18",
-        "contentHash": "OyhaU6Le9F3azkUW5eZ4xax5cYeMlOgQJ5BliXYUrRgCDm9+1mgkbmFzlZpKvJ0wuQQ+MGJT6fsAnaE0gZ2bsA==",
+        "requested": "[1.28.7, )",
+        "resolved": "1.28.7",
+        "contentHash": "RfpI+DdRKMN7KLAo7ircvgx3rvCRf+iw9puZ1/AdzofGqx9D9XDygkE3pn2Bx3jz66e71wI1J3UNDDt0viUinA==",
         "dependencies": {
           "Microsoft.Testing.Extensions.CodeCoverage": "18.5.2",
           "Microsoft.Testing.Extensions.Telemetry": "2.1.0",
           "Microsoft.Testing.Extensions.TrxReport": "2.1.0",
-          "TUnit.Assertions": "1.24.18",
-          "TUnit.Engine": "1.24.18"
+          "TUnit.Assertions": "1.28.7",
+          "TUnit.Engine": "1.28.7"
         }
       },
       "EnumerableAsyncProcessor": {
@@ -99,24 +99,24 @@
       },
       "TUnit.Assertions": {
         "type": "Transitive",
-        "resolved": "1.24.18",
-        "contentHash": "P+A9YayHaVp6QbaGOSqzfaYnOv6yKCTl7UMFXNgRwL+y9WM0U2rFTuEuvcT+JWEM3J0VwByUwFD1//+pNZp9sg=="
+        "resolved": "1.28.7",
+        "contentHash": "gVXcXtczcJJVTQq/72bFmBqf+QXYAAJ/J8I3YN6Jp1QPYgF4SVTv+bu8+4P2Dfjvy9u7bkfis6Hyg2DKxuELTA=="
       },
       "TUnit.Core": {
         "type": "Transitive",
-        "resolved": "1.24.18",
-        "contentHash": "0izzCGrfELlBknLNgZd78tuDgefokmzaKWR7HLyyRaCF7ga6JKSUvexrZybPqs5v0wMsUsX7FpMpsYajNiSiSg=="
+        "resolved": "1.28.7",
+        "contentHash": "OREoYzg9tzHEUFtaezXD3n6FoBp30u3W5xmkdlUBFIGXslruOwyBBm9ijDCQETWGwc1GzmgcoYUxCockzsty3g=="
       },
       "TUnit.Engine": {
         "type": "Transitive",
-        "resolved": "1.24.18",
-        "contentHash": "aJcSoBX6WTOuoyVQ5HrCUj2Zjnpkp5zphR2uU9uXnWZ7RaCrI8F9r+axcV3mLC4gXSZjra+33yxIO9tIOIQgYg==",
+        "resolved": "1.28.7",
+        "contentHash": "dLNhaJXQqUE2wOBwP9WKH42Xky2SyiUjy1Z/QqZzk7hJfoz/KK4QDQg4aBbqO/q5uJ9FWysrUg+xQAjITKdsQw==",
         "dependencies": {
           "EnumerableAsyncProcessor": "3.8.4",
           "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
           "Microsoft.Testing.Platform": "2.1.0",
           "Microsoft.Testing.Platform.MSBuild": "2.1.0",
-          "TUnit.Core": "1.24.18"
+          "TUnit.Core": "1.28.7"
         }
       },
       "guildwars2.tests.common": {

--- a/tests/GuildWars2.Tests/packages.lock.json
+++ b/tests/GuildWars2.Tests/packages.lock.json
@@ -102,9 +102,9 @@
       },
       "Polyfill": {
         "type": "Direct",
-        "requested": "[9.24.0, )",
-        "resolved": "9.24.0",
-        "contentHash": "fuc6Od4lAp7VbtQG9lWuJFgw+tpdj5uQWUgarYRkzdm/Jbq/YTqPSrX3mrvE8aM25u/j5IX+wFBxxhg/Rvmkkw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "HX4+jlB3OTAn+CiNLzuen/I7jgYLfNxDTsX3A7Ij285WYEbNwXPh1haHgeDinDum+m/pviBb8idK4JNUz1qS0Q=="
       },
       "System.Interactive": {
         "type": "Direct",
@@ -114,15 +114,15 @@
       },
       "TUnit": {
         "type": "Direct",
-        "requested": "[1.24.18, )",
-        "resolved": "1.24.18",
-        "contentHash": "OyhaU6Le9F3azkUW5eZ4xax5cYeMlOgQJ5BliXYUrRgCDm9+1mgkbmFzlZpKvJ0wuQQ+MGJT6fsAnaE0gZ2bsA==",
+        "requested": "[1.28.7, )",
+        "resolved": "1.28.7",
+        "contentHash": "RfpI+DdRKMN7KLAo7ircvgx3rvCRf+iw9puZ1/AdzofGqx9D9XDygkE3pn2Bx3jz66e71wI1J3UNDDt0viUinA==",
         "dependencies": {
           "Microsoft.Testing.Extensions.CodeCoverage": "18.5.2",
           "Microsoft.Testing.Extensions.Telemetry": "2.1.0",
           "Microsoft.Testing.Extensions.TrxReport": "2.1.0",
-          "TUnit.Assertions": "1.24.18",
-          "TUnit.Engine": "1.24.18"
+          "TUnit.Assertions": "1.28.7",
+          "TUnit.Engine": "1.28.7"
         }
       },
       "EnumerableAsyncProcessor": {
@@ -483,24 +483,24 @@
       },
       "TUnit.Assertions": {
         "type": "Transitive",
-        "resolved": "1.24.18",
-        "contentHash": "P+A9YayHaVp6QbaGOSqzfaYnOv6yKCTl7UMFXNgRwL+y9WM0U2rFTuEuvcT+JWEM3J0VwByUwFD1//+pNZp9sg=="
+        "resolved": "1.28.7",
+        "contentHash": "gVXcXtczcJJVTQq/72bFmBqf+QXYAAJ/J8I3YN6Jp1QPYgF4SVTv+bu8+4P2Dfjvy9u7bkfis6Hyg2DKxuELTA=="
       },
       "TUnit.Core": {
         "type": "Transitive",
-        "resolved": "1.24.18",
-        "contentHash": "0izzCGrfELlBknLNgZd78tuDgefokmzaKWR7HLyyRaCF7ga6JKSUvexrZybPqs5v0wMsUsX7FpMpsYajNiSiSg=="
+        "resolved": "1.28.7",
+        "contentHash": "OREoYzg9tzHEUFtaezXD3n6FoBp30u3W5xmkdlUBFIGXslruOwyBBm9ijDCQETWGwc1GzmgcoYUxCockzsty3g=="
       },
       "TUnit.Engine": {
         "type": "Transitive",
-        "resolved": "1.24.18",
-        "contentHash": "aJcSoBX6WTOuoyVQ5HrCUj2Zjnpkp5zphR2uU9uXnWZ7RaCrI8F9r+axcV3mLC4gXSZjra+33yxIO9tIOIQgYg==",
+        "resolved": "1.28.7",
+        "contentHash": "dLNhaJXQqUE2wOBwP9WKH42Xky2SyiUjy1Z/QqZzk7hJfoz/KK4QDQg4aBbqO/q5uJ9FWysrUg+xQAjITKdsQw==",
         "dependencies": {
           "EnumerableAsyncProcessor": "3.8.4",
           "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
           "Microsoft.Testing.Platform": "2.1.0",
           "Microsoft.Testing.Platform.MSBuild": "2.1.0",
-          "TUnit.Core": "1.24.18"
+          "TUnit.Core": "1.28.7"
         }
       },
       "guildwars2.tests.common": {


### PR DESCRIPTION
## Summary

Consolidates the conflicting Dependabot PRs #421 and #422 into a single update.

### Package updates

| Package | From | To | Type |
|---|---|---|---|
| Polyfill | 9.24.0 | 10.0.0 | Major |
| Spectre.Console | 0.54.0 | 0.55.0 | Minor |
| Spectre.Console.ImageSharp | 0.54.0 | 0.55.0 | Minor |
| TUnit | 1.24.18 | 1.28.7 | Minor |

### Breaking changes reviewed

**Polyfill 10.0.0** — Six `Directory.*` polyfill methods moved from `Polyfill.*` static class to C# 14 `extension(Directory)` syntax. This repo does not call any `Polyfill.EnumerateFiles/GetFiles/etc.` methods directly, so no code changes needed. The existing `LangVersion=preview` already satisfies the C# 14 requirement.

**Spectre.Console 0.55.0** — `Style` is now a struct; `Render` extension method removed. Neither is used in this repo.

**TUnit 1.24.18 → 1.28.7** — Only breaking change is dropping net6/net7 TFMs, which does not affect this repo (targets net10.0).

### Other changes

- **`dependabot.yml`**: Added `major` to the `nuget-dependencies` group so all NuGet updates (major + minor + patch) land in a single PR, preventing future conflicts between major-bump standalone PRs and the minor/patch group PR.
- **`dependabot-lockfile.yml`**: Extended the lock-file regeneration workflow to also trigger for `deps/*` branches (previously only ran for `dependabot[bot]` actor), so CI regenerates lock files for manual dependency update PRs.