### PR TITLE
Group all GitHub Actions to prevent conflicting Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,10 +31,10 @@ updates:
     schedule:
       interval: daily
     groups:
-      official-actions:
+      github-actions:
         applies-to: version-updates
         patterns:
-          - "actions/*"
+          - "*"
         update-types:
           - major
           - minor


### PR DESCRIPTION
The `official-actions` group only matched `actions/*`, leaving third-party actions like `codecov/codecov-action` and `docker/login-action` ungrouped. When multiple actions used in the same workflow file need updates simultaneously, Dependabot would generate separate PRs that conflict with each other.

This PR expands the pattern to `*` and renames the group to `github-actions` so all GitHub Actions are batched into a single PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1YRkYNtyv9KdHVTrXVPaX)_