### PR TITLE
Use TUnit tolerance assertions for point-of-interest coordinates

### DIFF
--- a/tests/GuildWars2.Tests/Features/Exploration/PointsOfInterest/PointOfInterestById.cs
+++ b/tests/GuildWars2.Tests/Features/Exploration/PointsOfInterest/PointOfInterestById.cs
@@ -20,8 +20,8 @@ public class PointOfInterestById(Gw2Client sut)
         await Assert.That(actual.Id).IsEqualTo(pointOfInterestId);
         await Assert.That(actual.Name).IsEqualTo("Leaning Grade");
         await Assert.That(actual.Floor).IsEqualTo(1);
-        await Assert.That(actual.Coordinates.X).IsEqualTo(52657.7f);
-        await Assert.That(actual.Coordinates.Y).IsEqualTo(32978.8f);
+        await Assert.That(actual.Coordinates.X).IsEqualTo(52657.7f).Within(0.001f);
+        await Assert.That(actual.Coordinates.Y).IsEqualTo(32978.8f).Within(0.001f);
         await Assert.That(actual.ChatLink).IsEqualTo("[&BCoCAAA=]");
     }
 }


### PR DESCRIPTION
Closes #416

## What changed

Point-of-interest coordinate values (`Coordinates.X` / `Coordinates.Y`) in `PointOfInterestById` were asserted with exact float equality, which is brittle to small floating-point variance. They now use TUnit's `.Within(0.001f)` tolerance so the assertions express the intended precision explicitly:

```csharp
await Assert.That(actual.Coordinates.X).IsEqualTo(52657.7f).Within(0.001f);
await Assert.That(actual.Coordinates.Y).IsEqualTo(32978.8f).Within(0.001f);
```

## Scope

I audited the whole test suite for brittle exact-float comparisons. These two coordinate assertions are the only float/double/decimal equality assertions present — other float-bearing models (`DamageMultiplier`, `AttributeAdjustment`, dye `Contrast`/`Saturation`/`Lightness`, etc.) are not asserted by exact value anywhere — so this fully addresses the issue.

## Note vs. the earlier attempt

This supersedes Copilot PR #467, which made the same two-line change but whose description claimed a new dedicated test was added (it was not). No redundant test is introduced here; the tolerance change is the complete fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7SbQh2gkhm3BBptR2Eqa6)_